### PR TITLE
fix: eliminate save-state deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^4.0.0",
-        "@actions/core": "^1.6.0",
-        "@actions/github": "^5.0.0",
-        "@actions/tool-cache": "^1.7.1",
+        "@actions/cache": "^4.1.0",
+        "@actions/core": "^1.11.1",
+        "@actions/github": "^5.1.1",
+        "@actions/tool-cache": "^1.7.2",
         "@octokit/rest": "^18.12.0",
         "uuid": "^8.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^4.0.0",
-    "@actions/core": "^1.6.0",
-    "@actions/github": "^5.0.0",
-    "@actions/tool-cache": "^1.7.1",
+    "@actions/cache": "^4.1.0",
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^5.1.1",
+    "@actions/tool-cache": "^1.7.2",
     "@octokit/rest": "^18.12.0",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
## Summary
Upgrades @actions/core and related @actions/* dependencies to their latest compatible versions, eliminating the deprecated save-state command warning in CI. The rebuilt dist/index.js now resolves to a @actions/core whose saveState prefers the GITHUB_STATE environment file over the deprecated save-state command.

Closes #8

## Changes
- Upgrade @actions/core ^1.6.0 -> ^1.11.1 (latest v1.x; uses environment files for saveState)
- Upgrade @actions/cache ^4.0.0 -> ^4.1.0
- Upgrade @actions/github ^5.0.0 -> ^5.1.1 (kept on v5 to remain CJS/ncc-compatible)
- Upgrade @actions/tool-cache ^1.7.1 -> ^1.7.2
- Refresh package-lock.json
- Rebuild dist/index.js (npm run build && npm run package) so the checked-in bundle matches source (check-dist passes)

## Validation
- [x] npm run lint
- [x] npm run test (14 tests, 3 files)
- [x] npm run build
- [x] npm run package
- [x] npm run format-check (via npm run all)

Built and validated against Node 24 (per .nvmrc).