### PR TITLE
chore: rebrand package.json from template (#24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "typescript-action",
-  "version": "0.0.0",
+  "name": "setup-v",
+  "version": "1.7.0",
   "private": true,
-  "description": "TypeScript template action",
+  "description": "Set up a Vlang (V) environment: download V and add it to the PATH",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/typescript-action.git"
+    "url": "git+https://github.com/vlang/setup-v.git"
   },
   "keywords": [
     "actions",
     "node",
     "setup"
   ],
-  "author": "",
+  "author": "vlang",
   "license": "MIT",
   "dependencies": {
     "@actions/cache": "^6.2.0",


### PR DESCRIPTION
## Summary
\package.json\ still carried template metadata from \ctions/typescript-action\ (vlang/setup-v#24). Rebranded:
- \
ame\: \	ypescript-action\ -> \setup-v\
- \description\: accurate summary of the action
- \epository.url\: \lang/setup-v\
- \uthor\: \lang\
- \ersion\: \1.7.0\ (synced with latest release v1.7)

## Verification
- \package.json\ parses as valid JSON
- \
pm run build\ (tsc) passes

Closes vlang/setup-v#24