### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy (#35)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of `setup-v` receives security updates.
+Older releases are not maintained; please upgrade to the newest release before
+reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v1.7.x  | :white_check_mark: |
+| < v1.7  | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this action, please **do not open a
+public GitHub issue**.
+
+Instead, report it privately through one of the following channels:
+
+- **GitHub Security Advisory:** use the
+  [Report a vulnerability](https://github.com/vlang/setup-v/security/advisories/new)
+  feature on this repository.
+- **Email:** send details to the maintainers at `security@vlang.io` (replace
+  `vlang.io` with the project's official security contact if different).
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Any suggested mitigation if you have one.
+
+We will acknowledge your report as soon as possible, keep you informed of our
+progress, and coordinate a fix and disclosure timeline with you. We ask that you
+give us a reasonable amount of time to address the issue before any public
+disclosure.
+
+## Scope
+
+This policy covers the `vlang/setup-v` GitHub Action source code and the
+released distributions. It does not cover the upstream V language project
+itself; report V-related issues to the V project maintainers.


### PR DESCRIPTION
## Summary
Adds a \SECURITY.md\ (vlang/setup-v#35) documenting:
- Supported versions (latest release only).
- Private vulnerability reporting via GitHub Security Advisories / email.
- What information to include and our disclosure coordination.
- Scope (this action only, not upstream V).

## Verification
Documentation-only change; no build/test impact.