### PR TITLE
fix: add missing id to check-dist compare step (#31)

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -36,6 +36,7 @@ jobs:
         run: npm run build
 
       - name: Compare the expected and actual dist/ directories
+        id: diff
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"


### PR DESCRIPTION
## Summary
In `.github/workflows/check-dist.yml` (vlang/setup-v#31), the `actions/upload-artifact` step's `if:` referenced `steps.diff.conclusion`, but the compare step only had a `name:` and no `id: diff`. The reference was therefore always undefined.

Added `id: diff` to the compare step so the conditional resolves correctly.

## Verification
YAML-only change; no build/test impact.
