### PR TITLE
docs: update README to v1.7, add CONTRIBUTING.md (#25)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Setup V
+
+Thanks for your interest in improving `setup-v`! This document explains how to
+get started.
+
+## Development setup
+
+You will need [Node.js](https://nodejs.org) (version 24 or later) and npm.
+
+```bash
+npm ci
+npm run build      # compile TypeScript to lib/ (type-check)
+npm run package    # bundle src/ into the committed dist/index.js via ncc
+npm run lint       # eslint
+npm run test       # vitest
+npm run all        # build + format + lint + package + test
+```
+
+## Project layout
+
+- `src/` — TypeScript source (action entry point, installer, helpers).
+- `dist/index.js` — the bundled output that GitHub Actions actually runs.
+  It is committed on purpose; rebuild it with `npm run package` after any
+  change to `src/` and include the regenerated `dist/` in your PR.
+- `.github/workflows/` — CI (`ci.yml`) and the `dist` consistency check
+  (`check-dist.yml`).
+
+## Pull requests
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your change, keeping the scope focused (one concern per PR).
+3. Run `npm run all` and make sure lint, tests, and the `dist` build pass.
+4. Commit `dist/index.js` (and its map) whenever you change `src/`.
+5. Open the PR with a clear description and reference any related issue
+   (e.g. `Closes #123`).
+
+## Reporting issues
+
+- For bugs and feature requests, open a [GitHub issue](https://github.com/vlang/setup-v/issues).
+- For security vulnerabilities, follow the policy in
+  [SECURITY.md](./SECURITY.md) and report privately — do not open a public issue.
+
+## Code style
+
+Code is formatted with Prettier and linted with ESLint
+(`eslint-plugin-github`). Run `npm run format` before committing.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GitHub Action that allows you to setup a V environment.
 ## Usage
 
 ```yaml
-- uses: vlang/setup-v@v1.4
+- uses: vlang/setup-v@v1.7
   with:
     # Personal access token (PAT) used to fetch the repository. The PAT is configured
     # with the local git config, which enables your scripts to run authenticated git
@@ -47,7 +47,7 @@ GitHub Action that allows you to setup a V environment.
     # Resolves the latest GitHub release tag. Can be combined with `check-latest`.
     stable: false
 
-    # Target architecture for V to use. Examples: linux, macos, windows. Will use system architecture by default.
+    # Target architecture for V to use. Examples: x86_64, arm64, aarch64, riscv64. Uses the system architecture by default.
     architecture: ''
 
     # Directory to install V into.


### PR DESCRIPTION
## Summary
Resolves vlang/setup-v#25:
- README usage example bumped from \@v1.4\ to \@v1.7\.
- README architecture input example aligned with \ction.yml\ (lists
  architectures \x86_64, arm64, aarch64, riscv64\ instead of OSes).
- Added \CONTRIBUTING.md\ — the README linked to it, but the file did not
  exist, leaving a broken link. The link now resolves.

## Verification
Documentation-only change; no build/test impact.