### PR TITLE
ci: standardize action versions and add Dependabot (#33)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Keep action versions consistent across workflows
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
       # If dist/ was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
## Summary
Resolves vlang/setup-v#33:
- `.github/workflows/check-dist.yml`: `actions/checkout` `v4` -> `v6` and `actions/upload-artifact` `v4` -> `v7` so they match `.github/workflows/ci.yml` (already on v6 / v7). `actions/setup-node` was already v6.
- Add `.github/dependabot.yml` to keep GitHub Actions and npm dependencies up to date (weekly).

## Verification
YAML-only change; no build/test impact.
