### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support the latest released major version of the action. Older
+releases are not actively patched, so please upgrade to the newest `vX` tag
+before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `v1.x`  | :white_check_mark: |
+| `< v1`  | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `vlang/setup-v`, please **do not**
+open a public issue or pull request.
+
+Instead, report it privately using one of the following channels:
+
+- **GitHub private vulnerability reporting** (preferred): open the
+  [Security tab](https://github.com/vlang/setup-v/security/advisories) of this
+  repository and choose **Report a vulnerability**. This keeps the details
+  confidential until a fix is released.
+- **Maintainer contact**: reach out to the maintainers via the repository's
+  security advisory discussion or by mentioning `@ulises-jeremias` in a private
+  advisory.
+
+### What to include
+
+Please provide enough detail to reproduce and assess the issue:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version(s) / tag(s).
+- Any suggested mitigation, if known.
+
+### What to expect
+
+- We will acknowledge your report as soon as possible.
+- We will work with you on a fix and coordinate a coordinated disclosure
+  timeline.
+- Once a fix is released, we will credit you (unless you prefer to remain
+  anonymous) in the associated security advisory.
+
+Thank you for helping keep `vlang/setup-v` and its users safe.


### PR DESCRIPTION
﻿## Summary

Adds a `SECURITY.md` vulnerability reporting policy for vlang/setup-v, as requested in #35.

## Changes

- Documents supported versions (latest `v1.x` line).
- Directs reporters to GitHub private vulnerability reporting (Security tab -> Report a vulnerability) as the preferred, confidential channel.
- Lists what to include in a report and what to expect (acknowledgement, coordinated disclosure, credit).

Closes #35
